### PR TITLE
fix: TransactionFee model rejects string gasPrice/baseFee/priorityFee from API

### DIFF
--- a/fireblocks/models/transaction_fee.py
+++ b/fireblocks/models/transaction_fee.py
@@ -28,11 +28,11 @@ class TransactionFee(BaseModel):
     TransactionFee
     """ # noqa: E501
     fee_per_byte: Optional[StrictStr] = Field(default=None, alias="feePerByte")
-    gas_price: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, alias="gasPrice")
+    gas_price: Optional[Union[StrictFloat, StrictInt, StrictStr]] = Field(default=None, alias="gasPrice")
     gas_limit: Optional[StrictStr] = Field(default=None, alias="gasLimit")
     network_fee: Optional[StrictStr] = Field(default=None, alias="networkFee")
-    base_fee: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="(optional) Base Fee according to EIP-1559 (ETH assets)", alias="baseFee")
-    priority_fee: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="(optional) Priority Fee according to EIP-1559 (ETH assets)", alias="priorityFee")
+    base_fee: Optional[Union[StrictFloat, StrictInt, StrictStr]] = Field(default=None, description="(optional) Base Fee according to EIP-1559 (ETH assets)", alias="baseFee")
+    priority_fee: Optional[Union[StrictFloat, StrictInt, StrictStr]] = Field(default=None, description="(optional) Priority Fee according to EIP-1559 (ETH assets)", alias="priorityFee")
     max_fee_per_gas_delta: Optional[StrictStr] = Field(default=None, description="Max Fee Per Gas Delta added only for EIP-1559 (ETH assets)", alias="maxFeePerGasDelta")
     l1_fee: Optional[StrictStr] = Field(default=None, description="Layer 1 fee for Layer 2 chains", alias="l1Fee")
     __properties: ClassVar[List[str]] = ["feePerByte", "gasPrice", "gasLimit", "networkFee", "baseFee", "priorityFee", "maxFeePerGasDelta", "l1Fee"]


### PR DESCRIPTION
## Summary

The Fireblocks API returns `gasPrice`, `baseFee`, and `priorityFee` as **strings** (e.g. `"1"`, `"0.005"`) in the `estimate_transaction_fee` response. However, the `TransactionFee` Pydantic model declares these fields as `Optional[Union[StrictFloat, StrictInt]]`.

`StrictFloat` and `StrictInt` reject string inputs without coercion, so Pydantic validation fails with errors like:

```
6 validation errors for TransactionFee
gasPrice.float
  Input should be a valid number [type=float_type, input_value='1', input_type=str]
gasPrice.int
  Input should be a valid integer [type=int_type, input_value='1', input_type=str]
baseFee.float
  Input should be a valid number [type=float_type, input_value='0.005', input_type=str]
...
```

The SDK then falls back to returning an `UnknownBaseModel` instead of `EstimatedTransactionFeeResponse`, which breaks downstream attribute access like `response.medium.network_fee`.

## Fix

Add `StrictStr` to the union type for `gas_price`, `base_fee`, and `priority_fee`:

```python
# Before
gas_price: Optional[Union[StrictFloat, StrictInt]]

# After
gas_price: Optional[Union[StrictFloat, StrictInt, StrictStr]]
```

This matches the actual API response format while preserving strict validation (no implicit coercion).

## Reproduction

Call `estimate_transaction_fee` for any EVM-based asset (e.g. Base Sepolia ETH). The API returns string values for gas fields, causing the SDK to emit a `UserWarning: Failed to deserialize response of type EstimatedTransactionFeeResponse` and return an `UnknownBaseModel`.